### PR TITLE
feat: describe-cluster showing meta-details part from specfile

### DIFF
--- a/cli/cmd/spec/describeCluster.go
+++ b/cli/cmd/spec/describeCluster.go
@@ -1,19 +1,28 @@
 package spec
 
 import (
-	"fmt"
+	"log"
 
+	"github.com/infracloudio/krius/pkg/specdescribe"
 	"github.com/spf13/cobra"
 )
 
 var describeClusterCmd = &cobra.Command{
 	Use:   "describe-cluster",
 	Short: "Describes the entire stack across multiple clusters and current state",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Need to implement describe-cluster on multicluster")
-	},
+	RunE:  specdescribe.DescribeClusterKrius,
+}
+
+func addDescribeConfigFileFlags(cmd *cobra.Command) error {
+	cmd.Flags().StringP("config-file", "c", "", "config file path")
+	err := cmd.MarkFlagRequired("config-file")
+	return err
 }
 
 func init() {
 	specCmd.AddCommand(describeClusterCmd)
+	err := addDescribeConfigFileFlags(describeClusterCmd)
+	if err != nil {
+		log.Print("Error Adding Config Flag: ", err)
+	}
 }

--- a/pkg/specdescribe/specdescribe.go
+++ b/pkg/specdescribe/specdescribe.go
@@ -1,0 +1,67 @@
+package specdescribe
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	client "github.com/infracloudio/krius/pkg/client"
+	spec "github.com/infracloudio/krius/pkg/specvalidate"
+	"github.com/spf13/cobra"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+var (
+	describeConfig client.Config
+)
+
+const (
+	configFile = "config-file"
+)
+
+func DescribeClusterKrius(cmd *cobra.Command, args []string) (err error) {
+
+	configFileFlag, _ := cmd.Flags().GetString(configFile)
+	loader, ruleSchemaLoader, err := spec.GetLoaders(configFileFlag)
+	if err != nil {
+		return err
+	}
+
+	valid, errors := spec.ValidateYML(loader, ruleSchemaLoader)
+	if !valid {
+		log.Println(errors)
+		return
+	}
+
+	getSpecFile, err := ioutil.ReadFile(configFileFlag)
+	if err != nil {
+		log.Fatal("Parse Error: Unable to read the spec file ")
+		return err
+	}
+
+	jsonSpecFile, err := yamlutil.ToJSON(getSpecFile)
+	if err != nil {
+		log.Fatal("Parse Error: Unable to conver the spec file to standard JSON format")
+		return err
+	}
+
+	err = json.Unmarshal(jsonSpecFile, &describeConfig)
+	if err != nil {
+		log.Fatal("Parse Error: Unable to parse spec")
+		return err
+	}
+
+	for _, each := range describeConfig.Clusters {
+		fmt.Print("\n---------------------------------------------------------------------------")
+		fmt.Print("\n Kubernetes Cluster Context: ", each.Name)
+		fmt.Print("\n Krius Cluster")
+		fmt.Print("\n - Name: ", each.Data["name"])
+		fmt.Print("\n - Namespace: ", each.Data["namespace"])
+		fmt.Print("\n - Type: ", each.Type)
+		fmt.Print("\n - ObjectConfiguration Name: ", each.Data["objStoreConfig"])
+		fmt.Print("\n---------------------------------------------------------------------------")
+
+	}
+	return err
+}


### PR DESCRIPTION
Package specdescribe impletements the experimental describe-cluster command which will shows the meta-data from the spec file which is passed. 

Example: 
```
krius spec describe-cluster -c /home/infracloud/test.yaml 

---------------------------------------------------------------------------
 Kubernetes Cluster Context: kind-cluster1
 Krius Cluster
 - Name: prometheus
 - Namespace: thanos1
 - Type: prometheus
 - ObjectConfiguration Name: bucketcluster2-new
---------------------------------------------------------------------------
---------------------------------------------------------------------------
 Kubernetes Cluster Context: kind-cluster1
 Krius Cluster
 - Name: thanos-cluster1
 - Namespace: thanos1
 - Type: thanos
 - ObjectConfiguration Name: bucketcluster2-new
---------------------------------------------------------------------------
```