### PR TITLE
Thanos image update, some issue with upstream code

### DIFF
--- a/pkg/client/utils.go
+++ b/pkg/client/utils.go
@@ -72,8 +72,7 @@ func (p Prometheus) createPrometheusSidecarValues() *values.Options {
 	var valueOpts values.Options
 	valueOpts.Values = []string{
 		fmt.Sprintf("commonLabels.replica=%s", p.Name),
-		fmt.Sprintf("prometheus.prometheusSpec.thanos.image=%s", "thanosio/thanos:v0.21.0-rc.0"),
-		fmt.Sprintf("prometheus.prometheusSpec.thanos.sha=%s", "dbf064aadd18cc9e545c678f08800b01a921cf6817f4f02d5e2f14f221bee17c"),
+		fmt.Sprintf("prometheus.prometheusSpec.thanos.image=%s", "quay.io/thanos/thanos:v0.28.1"),
 		fmt.Sprintf("prometheus.thanosService.enabled=%s", "true"),
 		fmt.Sprintf("prometheus.thanosServiceExternal.enabled=%s", "true"),
 		fmt.Sprintf("prometheus.thanosServiceExternal.labels.app=%s", "krius"),

--- a/pkg/specvalidate/multiClusterSpec.go
+++ b/pkg/specvalidate/multiClusterSpec.go
@@ -230,8 +230,7 @@ var RuleSchema = `
 				  "secretKey": {
 					"type": "string"
 				  }
-				},
-				"required": ["bucket"]
+				}
 			  },
 			  "bucketweb": {
 				"type": "object",


### PR DESCRIPTION
Thanos image update, some issue with upstream code (needs a permanent fix for upstream image handling)
Removed bucket as required key because no bucket name is needed in the Azure blob store